### PR TITLE
Use atom-text-editor tag in keymap

### DIFF
--- a/keymaps/gist.cson
+++ b/keymaps/gist.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor:not(.mini)':
+'atom-text-editor:not(.mini)':
   'alt-cmd-g': 'gist-it:gist-current-file'
   'shift-alt-cmd-g': 'gist-it:gist-selection'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "repository": "https://github.com/rpowelll/gist-it",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=0.x.0, <2.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Fixes Atom API 1.0 deprecation warning:

> Use the `atom-text-editor` tag instead of the `editor` class.