### PR TITLE
Add support for non-apple keyboard

### DIFF
--- a/keymaps/gist.cson
+++ b/keymaps/gist.cson
@@ -7,6 +7,10 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.atom-text-editor:not(.mini)':
+'.platform-darwin .atom-text-editor:not(.mini)':
   'alt-cmd-g': 'gist-it:gist-current-file'
   'shift-alt-cmd-g': 'gist-it:gist-selection'
+
+'.platform-win32 .atom-text-editor:not(.mini), .platform-linux .atom-text-editor:not(.mini)':
+  'alt-ctrl-g': 'gist-it:gist-current-file'
+  'shift-alt-ctrl-g': 'gist-it:gist-selection'

--- a/keymaps/gist.cson
+++ b/keymaps/gist.cson
@@ -7,10 +7,10 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.platform-darwin .atom-text-editor:not(.mini)':
+'.platform-darwin atom-text-editor:not(.mini)':
   'alt-cmd-g': 'gist-it:gist-current-file'
   'shift-alt-cmd-g': 'gist-it:gist-selection'
 
-'.platform-win32 .atom-text-editor:not(.mini), .platform-linux .atom-text-editor:not(.mini)':
+'.platform-win32 atom-text-editor:not(.mini), .platform-linux atom-text-editor:not(.mini)':
   'alt-ctrl-g': 'gist-it:gist-current-file'
   'shift-alt-ctrl-g': 'gist-it:gist-selection'


### PR DESCRIPTION
Use the platform targetting classes to replace the Cmd key with the Ctrl key on Linux and Windows.