### PR TITLE
Fixes #6 Automatically open new Gists in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ you can modify a variety of settings:
 - **Use Http (Boolean)** By default, all requests are made to the GitHub API over HTTPS.
   Setting this option allows communicating with an enterprise instance that is only
   served over HTTP.
+
+- **Open new Gist after create** If this option is set, new Gists will be opened
+in the default web browser immediately after they have been created.

--- a/lib/gist-it.coffee
+++ b/lib/gist-it.coffee
@@ -33,3 +33,8 @@ module.exports =
       description: 'Enable if your GitHub Enterprise instance is only available via HTTP, not HTTPS.'
       type: 'boolean'
       default: false
+    openAfterCreate:
+      title: 'Open new Gist after create'
+      description: 'Automatically open newly created Gists in the default web browser.'
+      type: 'boolean'
+      default: false

--- a/lib/gist-view.coffee
+++ b/lib/gist-view.coffee
@@ -2,6 +2,7 @@
 {CompositeDisposable} = require 'atom'
 
 Gist = require './gist-model'
+shell = require 'shell'
 
 module.exports =
 class GistView extends View
@@ -106,7 +107,12 @@ class GistView extends View
     @gist.description = @descriptionEditor.getText()
 
     @gist.post (response) =>
+      console.log(response)
       atom.clipboard.write response.html_url
+
+      if atom.config.get('gist-it.openAfterCreate')
+        shell.openExternal(response.html_url)
+
       @showUrlDisplay()
       setTimeout (=>
         @destroy()

--- a/lib/gist-view.coffee
+++ b/lib/gist-view.coffee
@@ -107,7 +107,6 @@ class GistView extends View
     @gist.description = @descriptionEditor.getText()
 
     @gist.post (response) =>
-      console.log(response)
       atom.clipboard.write response.html_url
 
       if atom.config.get('gist-it.openAfterCreate')


### PR DESCRIPTION
If the user chooses the associated config option, new Gists will be opened in the
default browser after they have been created.

The option defaults to `false`, so existing users will not be impacted.

![Settings](https://i.imgur.com/DkCO5Ac.png)